### PR TITLE
Key selector change

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,7 @@
     "bedrock-angular-alert": "^2.0.0",
     "bedrock-angular-modal": "^3.0.0",
     "bedrock-angular-resource": "^2.0.0",
-    "bedrock-angular-selector": "^3.0.0",
+    "bedrock-angular-selector": "^3.1.0",
     "forge": "~0.6.34"
   }
 }

--- a/key-selector-component.js
+++ b/key-selector-component.js
@@ -26,14 +26,6 @@ function register(module) {
 /* @ngInject */
 function Ctrl($scope) {
   var self = this;
-
-  $scope.$watchCollection(function() {
-    return self.keys;
-  }, function() {
-    if(!self.selected || $.inArray(self.selected, self.keys) === -1) {
-      self.selected = self.keys[0] || null;
-    }
-  });
 }
 
 return register;

--- a/key-selector.html
+++ b/key-selector.html
@@ -1,12 +1,14 @@
 <br-selector br-selected="$ctrl.selected"
   br-on-select="$ctrl.onSelect({selected: selected})"
+  br-on-deselect="$ctrl.onDeselect()"
   br-on-add-item="$ctrl.showAddModal=true"
   br-item-type="'Key'"
   br-items="$ctrl.keys"
   br-fixed="$ctrl.fixed"
-  br-show-choices="$ctrl.showChoices">
+  br-show-choices="$ctrl.showChoices"
+  br-allow-select-none="true">
   <br-selector-selected>
-    <div>
+    <div ng-if="$ctrl.selected">
       <strong>{{$ctrl.selected.label}}</strong>
       <br/>
       <small>{{$ctrl.selected.id}}</small>


### PR DESCRIPTION
Makes the key selector not default to the first key in a user's keys. Can also now deselect a preferred key by pulling in the empty selection option from this PR:  https://github.com/digitalbazaar/bedrock-angular-selector/pull/1
